### PR TITLE
3.1 可読性とメンテナンス性の向上

### DIFF
--- a/SmartCSxALAXALA/3.1-initial_setup_the_alaxala_device_via_smartcs.md
+++ b/SmartCSxALAXALA/3.1-initial_setup_the_alaxala_device_via_smartcs.md
@@ -80,15 +80,17 @@ login:
   gather_facts: no
   
   vars:
-  #ttynoはユーザごとに異なります。Playbook作成時に変更してください。
+  ### Variables that NEED to Change ###
+  - tty_no: '1'
+
+  ### Variables that should NOT change ###
   - ansible_connection: network_cli
   - ansible_network_os: smartcs
-  - ttyno: '1'
   
   tasks:
   - name: show version 
     smartcs_tty_command:
-      tty: '{{ ttyno }}'
+      tty: '{{ tty_no }}'
       recvchar:
       - 'login: '
       - '> '
@@ -98,8 +100,8 @@ login:
       - 'exit'
 ```
 ■Playbook内容の説明
-- tty:  
-コンソール経由で操作したいターゲットが接続されているtty番号を指定します。
+- tty: {{ tty_no }}  
+ターゲット機器が接続されているtty番号を設定します。ユーザごとに異なりますので、Playbook作成時にvarsに記載のtty_noの値を変更してください。  
 - recvchar:  
 <code>sendchar</code>オプションで送信した文字列を送信後、待ち受ける文字列を指定します。
 - sendchar:  
@@ -174,13 +176,13 @@ login:
 
 ■Playbookの編集箇所
 
-|vars |指定する値 |備考 | 
+| vars | 指定する値 | 備考 | 
 |:---|:---|:---|
-|ttyno |'1' |ユーザ毎に割り当てられているSmartCSの**tty**番号を指定します  |
+| tty_no | '1' | ユーザ毎に割り当てられているSmartCSの**tty**番号を指定します |
 
 <br>
 
-■Playbook(initial-setting_step1_user.yml)
+■Playbook(initial_setting_v1_user.yml)
 ```yaml
 ---
 - name: user settings from console using SartCS
@@ -188,18 +190,21 @@ login:
   gather_facts: no
   
   vars:
-  #ttynoはユーザごとに異なります。Playbook作成時に変更してください。
+  ### Variables that NEED to Change ###
+  - tty_no: '1'
+
+  ### Variables that should NOT change ###
   - ansible_connection: network_cli
   - ansible_network_os: smartcs
-  - inituser: 'operator'
-  - username: 'alaxala'
-  - password: 'secret2230'
-  - ttyno: '1'
+  
+  - ax_init_user: 'operator'
+  - ax_user: 'alaxala'
+  - ax_password: 'secret2230'
 
   tasks:
   - name: rename login user and setting password
     smartcs_tty_command:
-      tty: '{{ ttyno }}'
+      tty: '{{ tty_no }}'
       custom_response: on
       custom_response_delete_nl: on
       recvchar:
@@ -213,23 +218,23 @@ login:
       - '# '
       - '!# '
       sendchar:
-      - '{{ inituser }}'
+      - '{{ ax_init_user }}'
       - 'enable'
       - 'rename user'
-      - '{{ inituser }}'
-      - '{{ username }}'
+      - '{{ ax_init_user }}'
+      - '{{ ax_user }}'
       - 'password'
-      - '{{ password }}'
-      - '{{ password }}'
+      - '{{ ax_password }}'
+      - '{{ ax_password }}'
       - 'password enable-mode'
-      - '{{ password }}'
-      - '{{ password }}'
+      - '{{ ax_password }}'
+      - '{{ ax_password }}'
       - 'exit'
 ```
 
 ■Playbook内容の説明
-- tty: {{ ttyno }}  
-ターゲット機器が接続されているtty番号を設定します。ユーザごとに異なりますので、Playbook作成時にvarsに記載のttynoの値を変更してください。  
+- tty: {{ tty_no }}  
+ターゲット機器が接続されているtty番号を設定します。ユーザごとに異なりますので、Playbook作成時にvarsに記載のtty_noの値を変更してください。  
 - recvchar:   
 コンソール入出力で文字列送信後に待ち受ける文字列のリストを設定します。  
 - sendchar:  
@@ -238,7 +243,7 @@ login:
 
 ■実行例
 ```
-$ ansible-playbook initial-setting_step1_user.yml 
+$ ansible-playbook initial_setting_v1_user.yml 
 ```
 
 
@@ -307,14 +312,14 @@ login:
 
 ■Playbookの編集箇所
 
-|vars |Playbook例の値 |備考 | 
+| vars | Playbook例の値 | 備考 | 
 |:---|:---|:---|
-|ttyno |'1' |ユーザ毎に割り当てられているSmartCSの**tty**番号を指定します |
-|ipaddr |'192.168.128.2' |ユーザ毎に割り当てられている **ALAXALA IP**を指定します |
+| tty_no | '1' | ユーザ毎に割り当てられているSmartCSの**tty**番号を指定します |
+| ax_ipaddr | '192.168.128.2' | ユーザ毎に割り当てられている **ALAXALA IP**を指定します |
 
 <br>
 
-■Playbook(initial-setting_step2_ansible-reach.yml )
+■Playbook(initial_setting_v2_ansible_reach.yml )
 ```yaml
 ---
 - name: ansible-reach settings from console using SmartCS
@@ -322,20 +327,23 @@ login:
   gather_facts: no 
 
   vars:
-  #ipaddr、ttynoはユーザごとに異なります。Playbook作成時に変更してください。
+  ### Variables that NEED to Change ###
+  - tty_no: '1'
+  - ax_ipaddr: '192.168.128.2'
+
+  ### Variables that should NOT change ###
   - ansible_connection: network_cli
   - ansible_network_os: smartcs
-  - username: 'alaxala'
-  - password: 'secret2230'
-  - ipaddr: '192.168.128.2'
-  - subnet: '255.255.255.0'
-  - gateway: '192.168.128.254'
-  - ttyno: '1'
+  
+  - ax_user: 'alaxala'
+  - ax_password: 'secret2230'
+  - ax_subnet: '255.255.255.0'
+  - ax_gateway: '192.168.128.254'
 
   tasks:
   - name: setting ipaddr and ssh
     smartcs_tty_command:
-      tty: '{{ ttyno }}'
+      tty: '{{ tty_no }}'
       custom_response: on
       custom_response_delete_nl: on
       recvchar:
@@ -348,15 +356,15 @@ login:
       - '!(config-line)# '
       - '!(config-if)# '
       sendchar:
-      - '{{ username }}'
-      - '{{ password }}'
+      - '{{ ax_user }}'
+      - '{{ ax_password }}'
       - 'enable'
-      - '{{ password }}'
+      - '{{ ax_password }}'
       - 'configure'
       - 'interface vlan 1'
-      - 'ip address {{ ipaddr }} {{ subnet }}'
+      - 'ip address {{ ax_ipaddr }} {{ ax_subnet }}'
       - 'exit'
-      - 'ip route 0.0.0.0 0.0.0.0 {{ gateway }}'
+      - 'ip route 0.0.0.0 0.0.0.0 {{ ax_gateway }}'
       - 'ip ssh'
       - 'line vty 0 1'
       - 'transport input ssh'
@@ -379,7 +387,7 @@ Playbook内容（モジュールオプション）の説明
 
 ■実行例
 ```
-$ ansible-playbook initial-setting_step2_ansible-reach.yml
+$ ansible-playbook initial_setting_v2_ansible_reach.yml
 ```
 
 


### PR DESCRIPTION
Playbook内の
- varsで定義された変数のうち、WSで編集が必要な変数と不要な変数に分離
- Playbook内の日本語記載を英語に編集
- Playbook内の変数名について、どの製品/どのコネクションに紐づく値かを理解しやすく可読性が向上するように編集
- 3.1内の手順としてのSTEPと、init作業におけるstepが被っていたため、init作業に関わるPlaybook名を編集
- Playbookに関わるコメント / 解説文を修正