### PR TITLE
vlan id の修正

### DIFF
--- a/SmartCS×IOS/3.2-additional_setup_the_ios_device.md
+++ b/SmartCS×IOS/3.2-additional_setup_the_ios_device.md
@@ -143,7 +143,7 @@ vi add_vlan.yml
   vars:
   - ansible_command_timeout: 60
 
-  - vid: '00'
+  - vid: '100'
   - ipaddr: '192.168.0.1'
   - netmask: '255.255.255.0'
   - portif : '0/2'


### PR DESCRIPTION
https://github.com/ssol-smartcs/ansible-handson/commit/f2bbd99a5031dff9da6f7193a857820f1c1c00a9

の修正は、commit メッセージから察するに正しくは `100` かと思いましたので、そのように修正しました。
ご確認お願いします。
