### PR TITLE
save_when: changed  の説明の修正

### DIFF
--- a/SmartCS×IOS/3.2-additional_setup_the_ios_device.md
+++ b/SmartCS×IOS/3.2-additional_setup_the_ios_device.md
@@ -360,7 +360,7 @@ vi add_config.yml
 <code>host_vars/ios.yml</code>で定義した内容の中で定義した、ループ処理する要素を指定します。  
 
 - save_when: changed  
-Playbookの実行前後で、コンフィグに差分がある場合 設定を保存します。
+タスクの実行前後で、コンフィグに差分がある場合 設定を保存します。
 
 ■実行例  
 ```


### PR DESCRIPTION
`save_when: changed` は Playbook（全タスク）の実行による差分ではなく、
当該タスクによる差分によるものなので、タスクの実行前後という説明に修正しました。
