### PR TITLE
7/19 リハ時の修正

### DIFF
--- a/SmartCS×IOS/1.1-preparing_for_the_exercise.md
+++ b/SmartCS×IOS/1.1-preparing_for_the_exercise.md
@@ -183,7 +183,7 @@ cd ansible-handson
 
 プロンプトの先頭が<code>(ansible-handson)</code>となっていることを確認してください。
 ```
-[ec2-user@ip-172-26-10-114 ansible-handson]$ source ~/ansible-handson/bin/activate
+[ec2-user@ip-172-26-10-114 ~]$ source ~/ansible-handson/bin/activate
 (ansible-handson)[ec2-user@ip-172-26-10-114 ~]$ cd ansible-handson
 (ansible-handson)[ec2-user@ip-172-26-10-114 ansible-handson]$
 ```

--- a/SmartCS×IOS/1.1-preparing_for_the_exercise.md
+++ b/SmartCS×IOS/1.1-preparing_for_the_exercise.md
@@ -177,14 +177,14 @@ ssh ec2-user@XXX.XXX.XXX.XXX
 
 次のコマンドを実行して、python仮想環境を有効化してください。（SSHを接続しなおした際もこの作業が必要です）
 ```
+source ~/ansible-handson/bin/activate
 cd ansible-handson
-source bin/activate
 ```
 
 プロンプトの先頭が<code>(ansible-handson)</code>となっていることを確認してください。
 ```
-[ec2-user@ip-172-26-10-114 ~]$ cd ansible-handson
-[ec2-user@ip-172-26-10-114 ansible-handson]$ source bin/activate
+[ec2-user@ip-172-26-10-114 ansible-handson]$ source ~/ansible-handson/bin/activate
+(ansible-handson)[ec2-user@ip-172-26-10-114 ~]$ cd ansible-handson
 (ansible-handson)[ec2-user@ip-172-26-10-114 ansible-handson]$
 ```
 <br>

--- a/SmartCS×IOS/1.1-preparing_for_the_exercise.md
+++ b/SmartCS×IOS/1.1-preparing_for_the_exercise.md
@@ -175,7 +175,7 @@ ssh ec2-user@XXX.XXX.XXX.XXX
 
 ### Step 3. python仮想環境を有効化する
 
-次のコマンドを実行して、python仮想環境を有効化してください。
+次のコマンドを実行して、python仮想環境を有効化してください。（SSHを接続しなおした際もこの作業が必要です）
 ```
 cd ansible-handson
 source bin/activate

--- a/SmartCS×IOS/3.1-initial_setup_the_ios_device_via_smartcs.md
+++ b/SmartCS×IOS/3.1-initial_setup_the_ios_device_via_smartcs.md
@@ -46,7 +46,7 @@ cd exercise_3
 実行すると下記のようなプロンプト表示になります。<br>
 
 ```bash
-[ec2-user@ip-XXX-XXX-XXX-XXX ansible-handson]$ source ~/ansible-handson/bin/activate
+[ec2-user@ip-XXX-XXX-XXX-XXX ~]$ source ~/ansible-handson/bin/activate
 (ansible-handson)[ec2-user@ip-XXX-XXX-XXX-XXX ~]$ cd ansible-handson
 (ansible-handson)[ec2-user@ip-XXX-XXX-XXX-XXX ansible-handson]$ mkdir exercise_3
 (ansible-handson)[ec2-user@ip-XXX-XXX-XXX-XXX ansible-handson]$ cd exercise_3

--- a/SmartCS×IOS/3.1-initial_setup_the_ios_device_via_smartcs.md
+++ b/SmartCS×IOS/3.1-initial_setup_the_ios_device_via_smartcs.md
@@ -37,8 +37,8 @@
 なお、演習での操作はvenv上で行います。下記のコマンドを実施してください。<br>
 
 ```bash
+source ~/ansible-handson/bin/activate
 cd ansible-handson
-source bin/activate
 mkdir exercise_3
 cd exercise_3
 ```
@@ -46,8 +46,8 @@ cd exercise_3
 実行すると下記のようなプロンプト表示になります。<br>
 
 ```bash
-[ec2-user@ip-XXX-XXX-XXX-XXX ~]$ cd ansible-handson
-[ec2-user@ip-XXX-XXX-XXX-XXX ansible-handson]$ source bin/activate
+[ec2-user@ip-XXX-XXX-XXX-XXX ansible-handson]$ source ~/ansible-handson/bin/activate
+(ansible-handson)[ec2-user@ip-XXX-XXX-XXX-XXX ~]$ cd ansible-handson
 (ansible-handson)[ec2-user@ip-XXX-XXX-XXX-XXX ansible-handson]$ mkdir exercise_3
 (ansible-handson)[ec2-user@ip-XXX-XXX-XXX-XXX ansible-handson]$ cd exercise_3
 ```

--- a/SmartCS×IOS/3.2-additional_setup_the_ios_device.md
+++ b/SmartCS×IOS/3.2-additional_setup_the_ios_device.md
@@ -304,9 +304,14 @@ syslog:
 以上で、ファイルを保存し、エディターを終了します。<br>
 
 <code>host_vars/ios.yml</code>を利用し、各種サーバを設定するPlaybookは以下の内容となります。  
-<code>exercise_3</code>ディレクトリに戻り、Playbookを作成して実行します。  
-  
-次のコマンドを実施し、ファイルを作成しましょう。<br>
+
+まず<code>exercise_3</code>ディレクトリに戻ります。
+
+```bash
+cd ~/ansible-handson/exercise_3
+```
+
+続いてPlaybookを作成して実行します。次のコマンドを実施し、ファイルを作成しましょう。<br>
 
 ```bash
 vi add_config.yml

--- a/SmartCS×IOS/3.3-get_ios_device_information.md
+++ b/SmartCS×IOS/3.3-get_ios_device_information.md
@@ -180,7 +180,7 @@ ios_commandモジュールで指定した各コマンドの実行結果を、res
 ファイルのコピーを行うモジュールとなります。
 - content  
 ファイル内容を指定します。  
-`show running-config`を指定する為、Playbook実行結果として格納される`stdout_lines[8]`を指定します。
+`show running-config`を指定する為、Playbook実行結果として格納される`stdout_lines[5]`を指定します。
 - dest  
 コピー先（保存先）のファイル名を指定します。
 


### PR DESCRIPTION

# 演習3.2
- 「exercise_3ディレクトリに戻り」を見逃す方がいらっしゃったため、明示的に `cd` コマンドを実行する手順を追加

# 演習3.3
- 説明上の`stdout_lines` のインデックスをPlaybook に合わせて `5` に修正