### PR TITLE
開催日の年の追加と降順化

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,27 @@ SmartCS x Ansible のハンズオンコンテンツをまとめたページと�
 
 # ハンズオン コンテンツ
 
-### [SmartCS x ALAXALA x Ansible ハンズオン](./SmartCSxALAXALA/README.md)
+### [SmartCS x IOS x Ansible ハンズオン(第4回)](./SmartCSxIOS/README.md)
 
-- 時間：1月31日（金）13時〜18時（受付12時30分より）  
-場所：エーピーコミュニケーションズ 様
-
-### [SmartCS x IOS x Ansible ハンズオン(第1回)](https://github.com/ssol-smartcs/ansible-handson/blob/2021.07.29/SmartCS%C3%97IOS/README.md)
-
-- 時間：7月29日（木）13時〜17時（受付12時50分より）  
-場所：オンライン開催＠Zoom
-
-### [SmartCS x IOS x Ansible ハンズオン(第2回)](https://github.com/ssol-smartcs/ansible-handson/tree/2021.09.16/SmartCS%C3%97IOS/README.md)
-
-- 時間：9月16日（木）13時〜17時（受付12時50分より）  
+- 時間：2021年11月19日（金）13時〜17時（受付12時50分より）  
 場所：オンライン開催＠Zoom
 
 ### [SmartCS x IOS x Ansible ハンズオン(第3回)](https://github.com/ssol-smartcs/ansible-handson/blob/2021.10.21/SmartCSxIOS/README.md)
 
-- 時間：10月21日（木）13時〜17時（受付12時50分より）  
+- 時間：2021年10月21日（木）13時〜17時（受付12時50分より）  
 場所：オンライン開催＠Zoom
 
-### [SmartCS x IOS x Ansible ハンズオン(第4回)](./SmartCSxIOS/README.md)
+### [SmartCS x IOS x Ansible ハンズオン(第2回)](https://github.com/ssol-smartcs/ansible-handson/tree/2021.09.16/SmartCS%C3%97IOS/README.md)
 
-- 時間：11月19日（金）13時〜17時（受付12時50分より）  
+- 時間：2021年9月16日（木）13時〜17時（受付12時50分より）  
 場所：オンライン開催＠Zoom
+
+### [SmartCS x IOS x Ansible ハンズオン(第1回)](https://github.com/ssol-smartcs/ansible-handson/blob/2021.07.29/SmartCS%C3%97IOS/README.md)
+
+- 時間：2021年7月29日（木）13時〜17時（受付12時50分より）  
+場所：オンライン開催＠Zoom
+
+### [SmartCS x ALAXALA x Ansible ハンズオン](./SmartCSxALAXALA/README.md)
+
+- 時間：2020年1月31日（金）13時〜18時（受付12時30分より）  
+場所：エーピーコミュニケーションズ 様


### PR DESCRIPTION
開催日が年をまたいでいますので、分かりやすいように年を追加しました。

回数を重ねて、直近開催分が下の方に行ってしまっているので、
開催日の降順（新しいものが上）になるようにしました。